### PR TITLE
添加简单的 302 文件重定向支持

### DIFF
--- a/src/davhandler.rs
+++ b/src/davhandler.rs
@@ -55,6 +55,8 @@ pub struct DavConfig {
     pub(crate) indexfile: Option<String>,
     // read buffer size in bytes
     pub(crate) read_buf_size: Option<usize>,
+    // Dose GET on a file return 302 redirect.
+    pub(crate) redirect: Option<bool>
 }
 
 impl DavConfig {
@@ -134,6 +136,12 @@ impl DavConfig {
         this
     }
 
+    pub fn redirect(self, redirect: bool) -> Self {
+        let mut this = self;
+        this.redirect = Some(redirect);
+        this
+    }
+
     fn merge(&self, new: DavConfig) -> DavConfig {
         DavConfig {
             prefix: new.prefix.or_else(|| self.prefix.clone()),
@@ -145,6 +153,7 @@ impl DavConfig {
             autoindex: new.autoindex.or(self.autoindex),
             indexfile: new.indexfile.or_else(|| self.indexfile.clone()),
             read_buf_size: new.read_buf_size.or(self.read_buf_size),
+            redirect: new.redirect.or(self.redirect)
         }
     }
 }
@@ -163,6 +172,7 @@ pub(crate) struct DavInner {
     pub autoindex: Option<bool>,
     pub indexfile: Option<String>,
     pub read_buf_size: Option<usize>,
+    pub redirect: Option<bool>
 }
 
 impl From<DavConfig> for DavInner {
@@ -177,6 +187,7 @@ impl From<DavConfig> for DavInner {
             autoindex: cfg.autoindex,
             indexfile: cfg.indexfile,
             read_buf_size: cfg.read_buf_size,
+            redirect: cfg.redirect
         }
     }
 }
@@ -197,6 +208,7 @@ impl From<&DavConfig> for DavInner {
             autoindex: cfg.autoindex,
             indexfile: cfg.indexfile.clone(),
             read_buf_size: cfg.read_buf_size,
+            redirect: cfg.redirect
         }
     }
 }
@@ -213,6 +225,7 @@ impl Clone for DavInner {
             autoindex: self.autoindex,
             indexfile: self.indexfile.clone(),
             read_buf_size: self.read_buf_size,
+            redirect: self.redirect
         }
     }
 }

--- a/src/davhandler.rs
+++ b/src/davhandler.rs
@@ -56,7 +56,7 @@ pub struct DavConfig {
     // read buffer size in bytes
     pub(crate) read_buf_size: Option<usize>,
     // Dose GET on a file return 302 redirect.
-    pub(crate) redirect: Option<bool>
+    pub(crate) redirect: Option<bool>,
 }
 
 impl DavConfig {
@@ -153,7 +153,7 @@ impl DavConfig {
             autoindex: new.autoindex.or(self.autoindex),
             indexfile: new.indexfile.or_else(|| self.indexfile.clone()),
             read_buf_size: new.read_buf_size.or(self.read_buf_size),
-            redirect: new.redirect.or(self.redirect)
+            redirect: new.redirect.or(self.redirect),
         }
     }
 }
@@ -172,7 +172,7 @@ pub(crate) struct DavInner {
     pub autoindex: Option<bool>,
     pub indexfile: Option<String>,
     pub read_buf_size: Option<usize>,
-    pub redirect: Option<bool>
+    pub redirect: Option<bool>,
 }
 
 impl From<DavConfig> for DavInner {
@@ -187,7 +187,7 @@ impl From<DavConfig> for DavInner {
             autoindex: cfg.autoindex,
             indexfile: cfg.indexfile,
             read_buf_size: cfg.read_buf_size,
-            redirect: cfg.redirect
+            redirect: cfg.redirect,
         }
     }
 }
@@ -208,7 +208,7 @@ impl From<&DavConfig> for DavInner {
             autoindex: cfg.autoindex,
             indexfile: cfg.indexfile.clone(),
             read_buf_size: cfg.read_buf_size,
-            redirect: cfg.redirect
+            redirect: cfg.redirect,
         }
     }
 }
@@ -225,7 +225,7 @@ impl Clone for DavInner {
             autoindex: self.autoindex,
             indexfile: self.indexfile.clone(),
             read_buf_size: self.read_buf_size,
-            redirect: self.redirect
+            redirect: self.redirect,
         }
     }
 }

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -10,6 +10,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use futures_util::{future, Future, Stream, TryFutureExt};
 use http::StatusCode;
+use url::Url;
 
 use crate::davpath::DavPath;
 
@@ -295,7 +296,7 @@ pub trait DavFile: Debug + Send + Sync {
     fn read_bytes(&mut self, count: usize) -> FsFuture<bytes::Bytes>;
     fn seek(&mut self, pos: SeekFrom) -> FsFuture<u64>;
     fn flush(&mut self) -> FsFuture<()>;
-    fn redirect_url(&mut self) -> FsFuture<String> {
+    fn redirect_url(&mut self) -> FsFuture<Url> {
         notimplemented_fut!("redirect_url")
     }
 }

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -8,9 +8,8 @@ use std::io::SeekFrom;
 use std::pin::Pin;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use futures_util::{future, Future, Stream, TryFutureExt};
+use futures_util::{future, Future, FutureExt, Stream, TryFutureExt};
 use http::StatusCode;
-use url::Url;
 
 use crate::davpath::DavPath;
 
@@ -296,8 +295,8 @@ pub trait DavFile: Debug + Send + Sync {
     fn read_bytes(&mut self, count: usize) -> FsFuture<bytes::Bytes>;
     fn seek(&mut self, pos: SeekFrom) -> FsFuture<u64>;
     fn flush(&mut self) -> FsFuture<()>;
-    fn redirect_url(&mut self) -> FsFuture<Url> {
-        notimplemented_fut!("redirect_url")
+    fn redirect_url(&mut self) -> FsFuture<Option<String>> {
+        future::ready(Ok(None)).boxed()
     }
 }
 

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -295,6 +295,9 @@ pub trait DavFile: Debug + Send + Sync {
     fn read_bytes(&mut self, count: usize) -> FsFuture<bytes::Bytes>;
     fn seek(&mut self, pos: SeekFrom) -> FsFuture<u64>;
     fn flush(&mut self) -> FsFuture<()>;
+    fn redirect_url(&mut self) -> FsFuture<String> {
+        notimplemented_fut!("redirect_url")
+    }
 }
 
 /// File metadata. Basically type, length, and some timestamps.

--- a/src/handle_gethead.rs
+++ b/src/handle_gethead.rs
@@ -97,10 +97,8 @@ impl crate::DavInner {
             Some(redirect) => {
                 if redirect {
                     *res.status_mut() = StatusCode::FOUND;
-                    res.headers_mut().insert(
-                    "Location",
-                    file.redirect_url().await?.parse().unwrap(),
-                    );
+                    res.headers_mut()
+                        .insert("Location", file.redirect_url().await?.parse().unwrap());
                     return Ok(res);
                 }
             }

--- a/src/handle_gethead.rs
+++ b/src/handle_gethead.rs
@@ -93,6 +93,20 @@ impl crate::DavInner {
             res.headers_mut().typed_insert(etag);
         }
 
+        match self.redirect {
+            Some(redirect) => {
+                if redirect {
+                    *res.status_mut() = StatusCode::FOUND;
+                    res.headers_mut().insert(
+                    "Location",
+                    file.redirect_url().await?.parse().unwrap(),
+                    );
+                    return Ok(res);
+                }
+            }
+            None => {}
+        }
+
         // Apache always adds an Accept-Ranges header, even with partial
         // responses where it should be pretty obvious. So something somewhere
         // probably depends on that.

--- a/src/handle_gethead.rs
+++ b/src/handle_gethead.rs
@@ -96,12 +96,14 @@ impl crate::DavInner {
         match self.redirect {
             Some(redirect) => {
                 if redirect {
-                    *res.status_mut() = StatusCode::FOUND;
-                    res.headers_mut().insert(
-                        "Location",
-                        file.redirect_url().await?.as_str().parse().unwrap(),
-                    );
-                    return Ok(res);
+                    match file.redirect_url().await? {
+                        Some(url) => {
+                            res.headers_mut().insert("Location", url.parse().unwrap());
+                            *res.status_mut() = StatusCode::FOUND;
+                            return Ok(res);
+                        }
+                        None => {}
+                    }
                 }
             }
             None => {}

--- a/src/handle_gethead.rs
+++ b/src/handle_gethead.rs
@@ -97,8 +97,10 @@ impl crate::DavInner {
             Some(redirect) => {
                 if redirect {
                     *res.status_mut() = StatusCode::FOUND;
-                    res.headers_mut()
-                        .insert("Location", file.redirect_url().await?.parse().unwrap());
+                    res.headers_mut().insert(
+                        "Location",
+                        file.redirect_url().await?.as_str().parse().unwrap(),
+                    );
                     return Ok(res);
                 }
             }

--- a/src/handle_gethead.rs
+++ b/src/handle_gethead.rs
@@ -361,6 +361,7 @@ impl crate::DavInner {
                 w.push_str(
                     "\
                     <html><head>\n\
+                    <meta name=\"referrer\" content=\"no-referrer\" />\n\
                     <title>Index of ",
                 );
                 w.push_str(&upath);


### PR DESCRIPTION
对于一些非典型的后端，比如阿里云盘，在 GET 时可以通过 302 重定向到文件直链，从而使 WebDAV 客户端直接从阿里云盘服务器读取文件。