### PR TITLE
Fix missing From<std::io::Error> impls when compiling with memfs enabled but localfs disabled

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ actix-compat = [ "actix-web" ]
 warp-compat = [ "warp", "hyper" ]
 all = [ "actix-compat", "warp-compat" ]
 localfs = ["libc", "lru", "parking_lot"]
-memfs = []
+memfs = ["libc"]
 
 [[example]]
 name = "actix"


### PR DESCRIPTION
Ran into this pulling in the dep for a small project - another option would be to just imply `localfs` with `memfs` but figured this is more minimal for people who are only enabling `memfs`