### PR TITLE
Count KiB, GiB, etc. in binary units as suggested

### DIFF
--- a/src/handle_gethead.rs
+++ b/src/handle_gethead.rs
@@ -453,19 +453,13 @@ impl crate::DavInner {
 }
 
 fn display_size(size: u64) -> String {
-    if size <= 1000 {
-        return format!("{}    ", size);
-    }
-    if size <= 1_000_000 {
-        return format!("{} KiB", ((size / 10) as f64) / 100f64);
-    }
-    if size <= 1_000_000_000 {
-        return format!("{} MiB", ((size / 10_000) as f64) / 100f64);
-    }
-    if size <= 1_000_000_000_000 {
-        return format!("{} GiB", ((size / 10_000_000) as f64) / 100f64);
-    }
-    format!("{:2}TiB", ((size / 10_000_000_000) as f64) / 100f64)
+    let (formatted, unit) = ["KiB", "MiB", "GiB", "TiB", "PiB"]
+        .iter()
+        .zip(1..)
+        .find(|(_, power)| size >= 1024u64.pow(*power) && size < 1024u64.pow(power + 1))
+        .map(|(unit, power)| (size as f64 / 1024u64.pow(power) as f64, unit))
+        .unwrap_or_else(|| (size as f64, &"B"));
+    format!("{} {}", (formatted * 100f64).round() / 100f64, unit)
 }
 
 fn display_path(path: &DavPath) -> String {


### PR DESCRIPTION
As suggested in #7, the output of [`display_size()`](https://github.com/messense/dav-server-rs/blob/67f1b11adf99d740e4297b43c79387488904c4bc/src/handle_gethead.rs#L443) should actually use binary units (powers of 1024 instead of 1000) as suggested in the units supplied.

This should fix that issue, I did a few basic tests to confirm that the values are correct.

```rust
fn main() {
    assert_eq!(display_size(1000 * 56), "54.69 KiB");
    assert_eq!(display_size(1024 * 56), "56 KiB");
    assert_eq!(display_size(1024 * 1024 * 56), "56 MiB");
    assert_eq!(display_size(1024 * 1024 * 1024 * 56), "56 GiB");
    assert_eq!(display_size(1024 * 1024 * 1024 * 1024 * 56), "56 TiB");
    assert_eq!(display_size(1024 * 1024 * 1024 * 1024 * 1024 * 1023), "1023 PiB");
    assert_eq!(display_size(6_599_974_540), "6.15 GiB");
    assert_eq!(display_size(194_104_989), "185.11 MiB");
}
```

Fixes #7