### PR TITLE
Upgrade http library to 1.0, including some dependcies and hyper 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,10 +37,11 @@ required-features = [ "warp-compat" ]
 bytes = "1.0.1"
 futures-util = "0.3.16"
 futures-channel = "0.3.16"
-headers = "0.3.0"
+headers = "0.4.0"
 htmlescape = "0.3.1"
-http = "0.2.3"
-http-body = "0.4.0"
+http = "1.0.0"
+http-body = "1.0.0"
+http-body-util = "0.1.0"
 lazy_static = "1.4.0"
 libc = { version = "0.2.0", optional = true }
 log = "0.4.0"
@@ -58,13 +59,14 @@ uuid = { version = "1.1.2", features = ["v4"] }
 xml-rs = "0.8.0"
 xmltree = "0.10.0"
 
-hyper = {version = "0.14.0", optional = true }
+hyper = {version = "1.1.0", optional = true }
 warp = { version = "0.3.0", optional = true }
 actix-web = { version = "4.0.0-beta.15", optional = true }
 
 [dev-dependencies]
 clap = { version = "4.0.0", features = ["derive"] }
 env_logger = "0.10.0"
-hyper = { version = "0.14.0", features = [ "http1", "http2", "server", "stream", "runtime" ] }
+hyper = { version = "1.1.0", features = [ "http1", "server" ] }
+hyper-util = { version = "0.1.2", features = ["tokio"] }
 tokio = { version = "1.3.0", features = ["full"] }
 

--- a/examples/hyper.rs
+++ b/examples/hyper.rs
@@ -1,31 +1,53 @@
+use std::{convert::Infallible, net::SocketAddr};
+
+use hyper::{server::conn::http1, service::service_fn};
+use hyper_util::rt::TokioIo;
+use tokio::net::TcpListener;
+
 use dav_server::{fakels::FakeLs, localfs::LocalFs, DavHandler};
-use std::convert::Infallible;
 
 #[tokio::main]
 async fn main() {
     env_logger::init();
     let dir = "/tmp";
-    let addr = ([127, 0, 0, 1], 4918).into();
+    let addr = SocketAddr::from(([127, 0, 0, 1], 4918));
 
     let dav_server = DavHandler::builder()
         .filesystem(LocalFs::new(dir, false, false, false))
         .locksystem(FakeLs::new())
         .build_handler();
 
-    let make_service = hyper::service::make_service_fn(move |_| {
-        let dav_server = dav_server.clone();
-        async move {
-            let func = move |req| {
-                let dav_server = dav_server.clone();
-                async move { Ok::<_, Infallible>(dav_server.handle(req).await) }
-            };
-            Ok::<_, Infallible>(hyper::service::service_fn(func))
-        }
-    });
+    let listener = TcpListener::bind(addr).await.unwrap();
 
-    println!("hyper example: listening on {:?} serving {}", addr, dir);
-    let _ = hyper::Server::bind(&addr)
-        .serve(make_service)
-        .await
-        .map_err(|e| eprintln!("server error: {}", e));
+    println!("Serving on {:?}", addr);
+
+    // We start a loop to continuously accept incoming connections
+    loop {
+        let (stream, _) = listener.accept().await.unwrap();
+        let dav_server = dav_server.clone();
+
+        // Use an adapter to access something implementing `tokio::io` traits as if they implement
+        // `hyper::rt` IO traits.
+        let io = TokioIo::new(stream);
+
+        // Spawn a tokio task to serve multiple connections concurrently
+        tokio::task::spawn(async move {
+            // Finally, we bind the incoming connection to our `hello` service
+            if let Err(err) = http1::Builder::new()
+                // `service_fn` converts our function in a `Service`
+                .serve_connection(
+                    io,
+                    service_fn({
+                        move |req| {
+                            let dav_server = dav_server.clone();
+                            async move { Ok::<_, Infallible>(dav_server.handle(req).await) }
+                        }
+                    }),
+                )
+                .await
+            {
+                println!("Error serving connection: {:?}", err);
+            }
+        });
+    }
 }

--- a/src/body.rs
+++ b/src/body.rs
@@ -7,7 +7,6 @@ use std::task::{Context, Poll};
 
 use bytes::{Buf, Bytes};
 use futures_util::stream::Stream;
-use http::header::HeaderMap;
 use http_body::Body as HttpBody;
 
 use crate::async_stream::AsyncStream;
@@ -52,18 +51,11 @@ impl HttpBody for Body {
     type Data = Bytes;
     type Error = io::Error;
 
-    fn poll_data(
+    fn poll_frame(
         self: Pin<&mut Self>,
-        cx: &mut Context,
-    ) -> Poll<Option<Result<Self::Data, Self::Error>>> {
-        self.poll_next(cx)
-    }
-
-    fn poll_trailers(
-        self: Pin<&mut Self>,
-        _cx: &mut Context,
-    ) -> Poll<Result<Option<HeaderMap>, Self::Error>> {
-        Poll::Ready(Ok(None))
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<http_body::Frame<Self::Data>, Self::Error>>> {
+        self.poll_next(cx).map_ok(http_body::Frame::data)
     }
 }
 
@@ -119,19 +111,12 @@ where
     type Data = ReqData;
     type Error = ReqError;
 
-    fn poll_data(
+    fn poll_frame(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-    ) -> Poll<Option<Result<Self::Data, Self::Error>>> {
+    ) -> Poll<Option<Result<http_body::Frame<Self::Data>, Self::Error>>> {
         let this = self.project();
-        this.body.poll_next(cx)
-    }
-
-    fn poll_trailers(
-        self: Pin<&mut Self>,
-        _cx: &mut Context,
-    ) -> Poll<Result<Option<HeaderMap>, Self::Error>> {
-        Poll::Ready(Ok(None))
+        this.body.poll_next(cx).map_ok(http_body::Frame::data)
     }
 }
 

--- a/src/handle_gethead.rs
+++ b/src/handle_gethead.rs
@@ -127,7 +127,7 @@ impl crate::DavInner {
             if let Some(r) = req.headers().typed_get::<headers::Range>() {
                 trace!("handle_gethead: range header {:?}", r);
                 use std::ops::Bound::*;
-                for range in r.iter() {
+                for range in r.satisfiable_ranges(len) {
                     let (start, mut count, valid) = match range {
                         (Included(s), Included(e)) if e >= s => (s, e - s + 1, true),
                         (Included(s), Unbounded) if s <= len => (s, len - s, true),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,36 +70,57 @@
 //!
 //! ```no_run
 //! use std::convert::Infallible;
+//! use std::net::SocketAddr;
 //! use dav_server::{fakels::FakeLs, localfs::LocalFs, DavHandler};
+//! use hyper::server::conn::http1;
+//! use hyper::service::service_fn;
+//! use hyper_util::rt::TokioIo;
+//! use tokio::net::TcpListener;
 //!
 //! #[tokio::main]
 //! async fn main() {
+//!     env_logger::init();
 //!     let dir = "/tmp";
-//!     let addr = ([127, 0, 0, 1], 4918).into();
+//!     let addr = SocketAddr::from(([127, 0, 0, 1], 4918));
 //!
 //!     let dav_server = DavHandler::builder()
 //!         .filesystem(LocalFs::new(dir, false, false, false))
 //!         .locksystem(FakeLs::new())
 //!         .build_handler();
 //!
-//!     let make_service = hyper::service::make_service_fn(move |_| {
-//!         let dav_server = dav_server.clone();
-//!         async move {
-//!             let func = move |req| {
-//!                 let dav_server = dav_server.clone();
-//!                 async move {
-//!                     Ok::<_, Infallible>(dav_server.handle(req).await)
-//!                 }
-//!             };
-//!             Ok::<_, Infallible>(hyper::service::service_fn(func))
-//!         }
-//!     });
+//!     let listener = TcpListener::bind(addr).await.unwrap();
 //!
-//!     println!("Serving {} on {}", dir, addr);
-//!     let _ = hyper::Server::bind(&addr)
-//!         .serve(make_service)
-//!         .await
-//!         .map_err(|e| eprintln!("server error: {}", e));
+//!     println!("Serving on {:?}", addr);
+//!
+//!     // We start a loop to continuously accept incoming connections
+//!     loop {
+//!         let (stream, _) = listener.accept().await.unwrap();
+//!         let dav_server = dav_server.clone();
+//!
+//!         // Use an adapter to access something implementing `tokio::io` traits as if they implement
+//!         // `hyper::rt` IO traits.
+//!         let io = TokioIo::new(stream);
+//!
+//!         // Spawn a tokio task to serve multiple connections concurrently
+//!         tokio::task::spawn(async move {
+//!             // Finally, we bind the incoming connection to our `hello` service
+//!             if let Err(err) = http1::Builder::new()
+//!                 // `service_fn` converts our function in a `Service`
+//!                 .serve_connection(
+//!                     io,
+//!                     service_fn({
+//!                         move |req| {
+//!                             let dav_server = dav_server.clone();
+//!                             async move { Ok::<_, Infallible>(dav_server.handle(req).await) }
+//!                         }
+//!                     }),
+//!                 )
+//!                 .await
+//!             {
+//!                 println!("Error serving connection: {:?}", err);
+//!             }
+//!         });
+//!     }
 //! }
 //! ```
 //! [DavHandler]: struct.DavHandler.html


### PR DESCRIPTION
While testing to get  `dav-server-rs`  working with a recent `axum` release, I encountered some problems because `axum` is using http@1.0, while `dav-server-rs` was still based on http@0.2.3. 

Since the 1.0 release of `http` brings some stability & BC promises, I figured it might be work updating to the new release to this library is ready to be used with recent releases of all the frameworks building on http. 

I did not touch the `warp` and `actix` example yet, that would be the next step.

I fixed up the hyper examples (the latest hyper release dropped some QoL features which bloats the example a bit) and ran the litmus test suite. Results where as documented in the README.  