### PR TITLE
Reduce warp dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,8 +58,8 @@ uuid = { version = "1.1.2", features = ["v4"] }
 xml-rs = "0.8.0"
 xmltree = "0.10.0"
 
-hyper = {version = "0.14.0", optional = true }
-warp = { version = "0.3.0", optional = true }
+hyper = { version = "0.14.0", optional = true }
+warp = { version = "0.3.0", optional = true, default-features = false }
 actix-web = { version = "4.0.0-beta.15", optional = true }
 
 [dev-dependencies]
@@ -67,4 +67,3 @@ clap = { version = "4.0.0", features = ["derive"] }
 env_logger = "0.10.0"
 hyper = { version = "0.14.0", features = [ "http1", "http2", "server", "stream", "runtime" ] }
 tokio = { version = "1.3.0", features = ["full"] }
-


### PR DESCRIPTION
This also allows dependent projects to also remove the default features of warp reducing the number of dependencies.

Warps default features enable `multer` and `tokio-tungstenite`, which include about 15 additional transitive dependencies.
