### PR TITLE
Fix spelling mistake

### DIFF
--- a/src/fs.rs
+++ b/src/fs.rs
@@ -373,7 +373,7 @@ pub trait DavMetaData: Debug + BoxCloneMd + Send + Sync {
         None
     }
 
-    /// Is this a file and not a directory. Default: `!s_dir()`.
+    /// Is this a file and not a directory. Default: `!is_dir()`.
     fn is_file(&self) -> bool {
         !self.is_dir()
     }


### PR DESCRIPTION
Fix spelling mistake `!s_dir()` at documentation comment of `dav_server::fs::DavMetaData::is_file`