### PR TITLE
reflink::reflink_or_copy instead of std::fs::copy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ default = ["localfs", "memfs"]
 actix-compat = [ "actix-web" ]
 warp-compat = [ "warp", "hyper" ]
 all = [ "actix-compat", "warp-compat" ]
-localfs = ["libc", "lru", "parking_lot"]
+localfs = ["libc", "lru", "parking_lot", "reflink-copy"]
 memfs = ["libc"]
 
 [[example]]
@@ -62,6 +62,7 @@ xmltree = "0.10.0"
 hyper = { version = "1.1.0", optional = true }
 warp = { version = "0.3.0", optional = true, default-features = false }
 actix-web = { version = "4.0.0-beta.15", optional = true }
+reflink-copy = { version = "0.1.14", optional = true }
 
 [dev-dependencies]
 clap = { version = "4.0.0", features = ["derive"] }

--- a/src/localfs.rs
+++ b/src/localfs.rs
@@ -28,6 +28,7 @@ use pin_utils::pin_mut;
 use tokio::task;
 
 use libc;
+use reflink_copy::reflink_or_copy;
 
 use crate::davpath::DavPath;
 use crate::fs::*;
@@ -444,7 +445,7 @@ impl DavFileSystem for LocalFs {
             let path_to = self.fspath(to);
 
             match self
-                .blocking(move || std::fs::copy(path_from, path_to))
+                .blocking(move || reflink_or_copy(path_from, path_to))
                 .await
             {
                 Ok(_) => Ok(()),


### PR DESCRIPTION
Many modern file systems allow `COPY` to be implemented in a way that avoids duplication, similar to a hard link but allowing the contents of the files to diverge as a result of a later `write`.

Examples include XFS, ZFS, btrfs, bcachefs, Microsoft ReFS, Apple APFS.