### PR TITLE
File systems with authorization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ required-features = [ "warp-compat" ]
 
 [dependencies]
 bytes = "1.0.1"
+derivative = "2"
 dyn-clone = "1"
 futures-util = "0.3.16"
 futures-channel = "0.3.16"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ required-features = [ "warp-compat" ]
 
 [dependencies]
 bytes = "1.0.1"
+dyn-clone = "1"
 futures-util = "0.3.16"
 futures-channel = "0.3.16"
 headers = "0.4.0"

--- a/examples/auth.rs
+++ b/examples/auth.rs
@@ -1,0 +1,152 @@
+use std::{convert::Infallible, fmt::Display, net::SocketAddr, path::Path};
+
+use futures_util::{stream, StreamExt};
+use http::{Request, Response, StatusCode};
+use hyper::{body::Incoming, server::conn::http1, service::service_fn};
+use hyper_util::rt::TokioIo;
+use tokio::{net::TcpListener, task::spawn};
+
+use dav_server::{
+    body::Body,
+    davpath::DavPath,
+    fakels::FakeLs,
+    fs::{
+        DavDirEntry, DavFile, DavMetaData, FsFuture, FsResult, FsStream, GuardedFileSystem,
+        OpenOptions, ReadDirMeta,
+    },
+    localfs::LocalFs,
+    DavHandler,
+};
+
+/// The server example demonstrates a limited scope policy for access to the file system.
+/// Depending on the filter specified by the user in the request, one will receive only files or directories.
+/// For example, try this URLs:
+/// - dav://dirs:-@127.0.0.1:4918 — responds only with directories.
+/// - dav://files:-@127.0.0.1:4918 — responds only with files.
+#[tokio::main]
+async fn main() {
+    env_logger::init();
+    let dir = "/tmp";
+    let addr: SocketAddr = ([127, 0, 0, 1], 4918).into();
+    let fs = FilteredFs::new(dir);
+    let dav_server = DavHandler::builder()
+        .filesystem(Box::new(fs) as _)
+        .locksystem(FakeLs::new())
+        .build_handler();
+    let listener = TcpListener::bind(addr).await.unwrap();
+    println!("Listening {addr}");
+    loop {
+        let (stream, _client_addr) = listener.accept().await.unwrap();
+        let dav_server = dav_server.clone();
+        let io = TokioIo::new(stream);
+        spawn(async move {
+            let service = service_fn(move |request| handle(request, dav_server.clone()));
+            if let Err(err) = http1::Builder::new().serve_connection(io, service).await {
+                eprintln!("Failed serving: {err:?}");
+            }
+        });
+    }
+}
+
+async fn handle(
+    request: Request<Incoming>,
+    handler: DavHandler<Filter>,
+) -> Result<Response<Body>, Infallible> {
+    /// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/WWW-Authenticate
+    static AUTH_CHALLENGE: &str = "Basic realm=\"Specify the directory entries' filter \
+        as a username: `dirs`, `files` or `all`; password — any string\"";
+    let filter = match Filter::from_request(&request) {
+        Ok(f) => f,
+        Err(err) => {
+            let response = Response::builder()
+                .status(StatusCode::UNAUTHORIZED)
+                .header("WWW-Authenticate", AUTH_CHALLENGE)
+                .body(err.to_string().into())
+                .expect("Auth error response must be built fine");
+            return Ok(response);
+        }
+    };
+    Ok(handler.handle_guarded(request, filter).await)
+}
+
+#[derive(Clone)]
+struct FilteredFs {
+    inner: Box<LocalFs>,
+}
+
+impl FilteredFs {
+    fn new(dir: impl AsRef<Path>) -> Self {
+        Self {
+            inner: LocalFs::new(dir, false, false, false),
+        }
+    }
+}
+
+impl GuardedFileSystem<Filter> for FilteredFs {
+    fn open<'a>(
+        &'a self,
+        path: &'a DavPath,
+        options: OpenOptions,
+        _credentials: &'a Filter,
+    ) -> FsFuture<Box<dyn DavFile>> {
+        self.inner.open(path, options, &())
+    }
+
+    fn read_dir<'a>(
+        &'a self,
+        path: &'a DavPath,
+        meta: ReadDirMeta,
+        filter: &'a Filter,
+    ) -> FsFuture<FsStream<Box<dyn DavDirEntry>>> {
+        Box::pin(async move {
+            let mut stream = self.inner.read_dir(path, meta, &()).await?;
+            let mut entries = Vec::default();
+            while let Some(entry) = stream.next().await {
+                let entry = entry?;
+                if filter.matches(entry.as_ref()).await? {
+                    entries.push(Ok(entry));
+                }
+            }
+            Ok(Box::pin(stream::iter(entries)) as _)
+        })
+    }
+
+    fn metadata<'a>(
+        &'a self,
+        path: &'a DavPath,
+        _credentials: &'a Filter,
+    ) -> FsFuture<Box<dyn DavMetaData>> {
+        self.inner.metadata(path, &())
+    }
+}
+
+#[derive(Clone)]
+enum Filter {
+    All,
+    Files,
+    Dirs,
+}
+
+impl Filter {
+    fn from_request(request: &Request<Incoming>) -> Result<Self, Box<dyn Display>> {
+        use headers::{authorization::Basic, Authorization, HeaderMapExt};
+
+        let auth = request
+            .headers()
+            .typed_get::<Authorization<Basic>>()
+            .ok_or(Box::new("please auth") as _)?;
+        match auth.username() {
+            "all" => Ok(Filter::All),
+            "files" => Ok(Filter::Files),
+            "dirs" => Ok(Filter::Dirs),
+            _ => Err(Box::new("unexpected filter value") as _),
+        }
+    }
+
+    async fn matches(&self, entry: &dyn DavDirEntry) -> FsResult<bool> {
+        if let Filter::All = self {
+            return Ok(true);
+        }
+        Ok(entry.is_dir().await? == matches!(self, Filter::Dirs))
+    }
+}

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -307,8 +307,11 @@ pub trait DavFileSystem {
 /// For file systems without access control, implement simpler [`DavFileSystem`] trait,
 /// for which there's a blanket implementation of `GuardedFileSystem<()>`.
 ///
+/// See also the [auth example].
+///
 /// [HTTP security]: https://datatracker.ietf.org/doc/html/rfc2616#section-15
 /// [WebDAV security]: https://datatracker.ietf.org/doc/html/rfc4918#section-20
+/// [auth example]: https://github.com/messense/dav-server-rs/blob/main/examples/auth.rs
 pub trait GuardedFileSystem<C>: Send + Sync + DynClone
 where
     C: Clone + Send + Sync + 'static,

--- a/src/handle_options.rs
+++ b/src/handle_options.rs
@@ -3,9 +3,9 @@ use http::{Request, Response};
 
 use crate::body::Body;
 use crate::util::{dav_method, DavMethod};
-use crate::DavResult;
+use crate::{DavInner, DavResult};
 
-impl crate::DavInner {
+impl<C: Clone + Send + Sync + 'static> DavInner<C> {
     pub(crate) async fn handle_options(&self, req: &Request<()>) -> DavResult<Response<Body>> {
         let mut res = Response::new(Body::empty());
 
@@ -35,7 +35,7 @@ impl crate::DavInner {
         };
 
         let path = self.path(req);
-        let meta = self.fs.metadata(&path).await;
+        let meta = self.fs.metadata(&path, &self.credentials).await;
         let is_unmapped = meta.is_err();
         let is_file = meta.map(|m| m.is_file()).unwrap_or_default();
         let is_star = path.is_star() && method == DavMethod::Options;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,8 @@
 //!
 //! - the library contains a [HTTP handler][DavHandler].
 //! - you supply a [filesystem][DavFileSystem] for backend storage, which can optionally
-//!   implement reading/writing [DAV properties][DavProp].
+//!   implement reading/writing [DAV properties][DavProp]. If the file system requires
+//!   authorization, implement a [special trait][GuardedFileSystem].
 //! - you can supply a [locksystem][DavLockSystem] that handles webdav locks.
 //!
 //! The handler in this library works with the standard http types
@@ -57,10 +58,20 @@
 //! - [`LocalFs`]: serves a directory on the local filesystem
 //! - [`MemFs`]: ephemeral in-memory filesystem. supports DAV properties.
 //!
+//! You're able to implement custom filesystem adapter:
+//!
+//! - [`DavFileSystem`]: without authorization.
+//! - [`GuardedFileSystem`]: when access control is required.
+//!
 //! Also included are two locksystems:
 //!
 //! - [`MemLs`]: ephemeral in-memory locksystem.
 //! - [`FakeLs`]: fake locksystem. just enough LOCK/UNLOCK support for macOS/Windows.
+//!
+//! External filesystem adapter implementations:
+//!
+//! - [`OpendalFs`](https://github.com/apache/opendal/tree/main/integrations/dav-server):
+//!   connects various storage protocols via [OpenDAL](https://github.com/apache/opendal).
 //!
 //! ## Example.
 //!

--- a/src/ls.rs
+++ b/src/ls.rs
@@ -10,6 +10,8 @@
 use crate::davpath::DavPath;
 use std::fmt::Debug;
 use std::time::{Duration, SystemTime};
+
+use dyn_clone::{clone_trait_object, DynClone};
 use xmltree::Element;
 
 /// Type of the locks returned by DavLockSystem methods.
@@ -34,7 +36,7 @@ pub struct DavLock {
 }
 
 /// The trait that defines a locksystem.
-pub trait DavLockSystem: Debug + Sync + Send + BoxCloneLs {
+pub trait DavLockSystem: Debug + Send + Sync + DynClone {
     /// Lock a node. Returns `Ok(new_lock)` if succeeded,
     /// or `Err(conflicting_lock)` if failed.
     fn lock(
@@ -77,22 +79,4 @@ pub trait DavLockSystem: Debug + Sync + Send + BoxCloneLs {
     fn delete(&self, path: &DavPath) -> Result<(), ()>;
 }
 
-#[doc(hidden)]
-pub trait BoxCloneLs {
-    fn box_clone(&self) -> Box<dyn DavLockSystem>;
-}
-
-// generic Clone, calls implementation-specific box_clone().
-impl Clone for Box<dyn DavLockSystem> {
-    fn clone(&self) -> Box<dyn DavLockSystem> {
-        self.box_clone()
-    }
-}
-
-// implementation-specific clone.
-#[doc(hidden)]
-impl<LS: Clone + DavLockSystem + 'static> BoxCloneLs for LS {
-    fn box_clone(&self) -> Box<dyn DavLockSystem> {
-        Box::new((*self).clone())
-    }
-}
+clone_trait_object! {DavLockSystem}

--- a/src/voidfs.rs
+++ b/src/voidfs.rs
@@ -1,26 +1,34 @@
 //! Placeholder filesystem. Returns FsError::NotImplemented on every method.
 //!
+use std::{any::Any, marker::PhantomData};
 
 use crate::davpath::DavPath;
 use crate::fs::*;
-use std::any::Any;
 
 /// Placeholder filesystem.
-#[derive(Debug, Clone)]
-pub struct VoidFs;
-
-pub fn is_voidfs(fs: &dyn Any) -> bool {
-    fs.is::<Box<VoidFs>>()
+#[derive(Clone, Debug)]
+pub struct VoidFs<C: Clone = ()> {
+    _marker: PhantomData<C>,
 }
 
-impl VoidFs {
-    pub fn new() -> Box<VoidFs> {
-        Box::new(VoidFs)
+pub fn is_voidfs<C: Clone + Send + Sync + 'static>(fs: &dyn Any) -> bool {
+    fs.is::<Box<VoidFs<C>>>()
+}
+
+impl<C: Clone + Send + Sync + 'static> VoidFs<C> {
+    pub fn new() -> Box<Self> {
+        Box::new(Self {
+            _marker: Default::default(),
+        })
     }
 }
 
-impl DavFileSystem for VoidFs {
-    fn metadata<'a>(&'a self, _path: &'a DavPath) -> FsFuture<Box<dyn DavMetaData>> {
+impl<C: Clone + Send + Sync + 'static> GuardedFileSystem<C> for VoidFs<C> {
+    fn metadata<'a>(
+        &'a self,
+        _path: &'a DavPath,
+        _credentials: &C,
+    ) -> FsFuture<Box<dyn DavMetaData>> {
         Box::pin(async { Err(FsError::NotImplemented) })
     }
 
@@ -28,11 +36,17 @@ impl DavFileSystem for VoidFs {
         &'a self,
         _path: &'a DavPath,
         _meta: ReadDirMeta,
+        _credentials: &C,
     ) -> FsFuture<FsStream<Box<dyn DavDirEntry>>> {
         Box::pin(async { Err(FsError::NotImplemented) })
     }
 
-    fn open<'a>(&'a self, _path: &'a DavPath, _options: OpenOptions) -> FsFuture<Box<dyn DavFile>> {
+    fn open<'a>(
+        &'a self,
+        _path: &'a DavPath,
+        _options: OpenOptions,
+        _credentials: &C,
+    ) -> FsFuture<Box<dyn DavFile>> {
         Box::pin(async { Err(FsError::NotImplemented) })
     }
 }
@@ -44,7 +58,8 @@ mod tests {
 
     #[test]
     fn test_is_void() {
-        assert!(is_voidfs(&VoidFs::new()));
-        assert!(!is_voidfs(&MemFs::new()));
+        assert!(is_voidfs::<i32>(&VoidFs::<i32>::new()));
+        assert!(is_voidfs::<()>(&VoidFs::<()>::new()));
+        assert!(!is_voidfs::<()>(&MemFs::new()));
     }
 }


### PR DESCRIPTION
Let's say you need to implement a WebDAV server with access control to files, directories and various file system functions. Users must authenticate with a token or password specified in the authorization headers.

I tried to implement similar access control using a few different hacks around the `dav_server`, but it was unsuccessful. In particular, I don't recommend trying to encode anything to pass to the file system adapter in file paths, since the `dav_server` needs them to provide the full path to the files in its responses.

To provide access control to file systems of this kind, I organized access to file system adapters through the `GuardedFileSystem<C>` trait, whose methods require a reference to generic credentials `C` to operate. I kept the same stateless approach to handling file system requests. The `DavHandler<C>` receives credentials from the library user in the `DavHandler::<C>::handle_guarded` method.

## Backward compatibility   

I want to preserve the support of old `DavFileSystem` implementations. Writing new adapters to file systems without access control shouldn't become any more difficult either. For example, introducing a `GuardedFileSystem` doesn't require any changes to [`dav-server-opendalfs`](https://github.com/apache/opendal/tree/main/integrations/dav-server) (can be compiled as is).   

For this purpose, blanket implementation `GuardedFileSystem<()>` for `DavFileSystem` was made. It required figuring out how `Box<dyn GuardedFileSystem<C>>` would be cloned. The old approach with `BoxCloneFs` required casting a `Box<dyn DavFileSystem>` into `Box<dyn GuardedFileSystem<()>>` which is [problematic](https://users.rust-lang.org/t/how-do-i-cast-box-dyn-foo-to-box-dyn-bar-properly/66393). Instead, I took a crate from dtolnay — [`dyn-clone`](https://docs.rs/dyn-clone/latest/dyn_clone/), which solves the problem of cloning `Box<dyn X>` — thanks to it, a trait can be object-safe, and at the same time impose a requirement on the cloning of its implementations.

Since `BoxCloneFs` is no longer needed, I suggest removing this trait. Even though it was marked as `#[doc(hidden)]`, it's essentially a **backwards-incompatible change**, but it won't require many edits from those maintaining their `DavFileSystem` implementations and who used `BoxCloneFs`. Since we already use `dyn-clone` for file system types, I used the same approach for `DavLockSystem` and `DavMetaData` (`BoxCloneLs` and `BoxCloneMd` were removed too).   

The old methods `DavHandler::handle` and others without access control retained their signature and the code with them doesn't require refactoring since the generic credentials parameter `C` has a default value `C = ()`.   

The `litmus` server example `examples/sample-litmus-server.rs` reads auth headers but doesn't use credentials in the file system adapter, so it doesn't require refactoring.   

## Examples   

- Simple server with access control as documentation — `examples/auth.rs`.   
   
## To do   

1. The `DavHandler<C>` could take the principal (to specify locks' owner) automatically from the credentials type parameter `C` if it implements the `Principal` trait (not implemented). I decided that the confusion that such a feature would introduce was not worth the loss of flexibility in specifying the principal.   
2. The `if_match_get_tokens` function needs to be refactored as the method of `DavInner`, since half of its 6 arguments are already `DavInner`'s fields. I didn't do this because it would introduce too many changes outside the scope of the pull request.   
3. We have to clone all the `DavConfig` fields to construct the `DavInner`, then we clone them to handle asynchronous requests to the `DavInner`, after which we clone a bunch of them into `PropWriter` (which is also cloned) for directory traversal. Most likely we should relate to `DavInner` through `self: Arc<Self>` (or `&self`) and clone the `Arc` if necessary to prevent excess allocations.