### PR TITLE
fix: remove nanoseconds in creationdate for Windows compatibility

### DIFF
--- a/src/handle_props.rs
+++ b/src/handle_props.rs
@@ -24,7 +24,9 @@ use crate::fs::*;
 use crate::handle_lock::{list_lockdiscovery, list_supportedlock};
 use crate::ls::*;
 use crate::util::MemBuffer;
-use crate::util::{dav_xml_error, systemtime_to_httpdate, systemtime_to_rfc3339};
+use crate::util::{
+    dav_xml_error, systemtime_to_httpdate, systemtime_to_rfc3339_without_nanosecond,
+};
 use crate::{DavInner, DavResult};
 
 const NS_APACHE_URI: &str = "http://apache.org/dav/props/";
@@ -693,7 +695,7 @@ impl<C: Clone + Send + Sync + 'static> PropWriter<C> {
                 match prop.name.as_str() {
                     "creationdate" => {
                         if let Ok(time) = meta.created() {
-                            let tm = systemtime_to_rfc3339(time);
+                            let tm = systemtime_to_rfc3339_without_nanosecond(time);
                             return self.build_elem(docontent, pfx, prop, tm);
                         }
                         // use ctime instead - apache seems to do this.
@@ -704,7 +706,7 @@ impl<C: Clone + Send + Sync + 'static> PropWriter<C> {
                                     time = mtime;
                                 }
                             }
-                            let tm = systemtime_to_rfc3339(time);
+                            let tm = systemtime_to_rfc3339_without_nanosecond(time);
                             return self.build_elem(docontent, pfx, prop, tm);
                         }
                     }


### PR DESCRIPTION
The bundled WebDAV client in Windows 7 ~ 11 (UA = Microsoft-WebDAV-MiniRedir) cannot parse time with nanoseconds.