### PR TITLE
Replace derivative with derive-where

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,6 @@ required-features = [ "warp-compat" ]
 
 [dependencies]
 bytes = "1.0.1"
-derivative = "2"
 dyn-clone = "1"
 futures-util = "0.3.16"
 futures-channel = "0.3.16"
@@ -65,6 +64,7 @@ hyper = { version = "1.1.0", optional = true }
 warp = { version = "0.3.0", optional = true, default-features = false }
 actix-web = { version = "4.0.0-beta.15", optional = true }
 reflink-copy = { version = "0.1.14", optional = true }
+derive-where = "1.6.0"
 
 [dev-dependencies]
 clap = { version = "4.0.0", features = ["derive"] }

--- a/src/davhandler.rs
+++ b/src/davhandler.rs
@@ -7,7 +7,7 @@ use std::io;
 use std::sync::Arc;
 
 use bytes::{self, buf::Buf};
-use derivative::Derivative;
+use derive_where::derive_where;
 use futures_util::stream::Stream;
 use headers::HeaderMapExt;
 use http::{Request, Response, StatusCode};
@@ -32,15 +32,15 @@ use crate::voidfs::{VoidFs, is_voidfs};
 /// The [`handle`](Self::handle) and [`handle_with`](Self::handle_with) methods do the actual work.
 ///
 /// Type parameter `C` represents credentials for file systems with access control.
-#[derive(Clone, Derivative)]
-#[derivative(Default(bound = ""))]
+#[derive(Clone)]
+#[derive_where(Default)]
 pub struct DavHandler<C = ()> {
     pub(crate) config: Arc<DavConfig<C>>,
 }
 
 /// Configuration of the handler.
-#[derive(Clone, Derivative)]
-#[derivative(Default(bound = ""))]
+#[derive(Clone)]
+#[derive_where(Default)]
 pub struct DavConfig<C = ()> {
     // Prefix to be stripped off when handling request.
     pub(crate) prefix: Option<String>,


### PR DESCRIPTION
Two reasons for this change:

1. [derivative is no longer maintained](https://rustsec.org/advisories/RUSTSEC-2024-0388.html)
2. derivative still uses syn v1, while all other crates use syn, leading to a duplicate dependency (see `cargo tree -d`). This caused higher build times, bigger binaries etc.