### PR TITLE
MOVE must remove an existing Destination before renaming

### DIFF
--- a/src/handle_copymove.rs
+++ b/src/handle_copymove.rs
@@ -263,8 +263,7 @@ impl<C: Clone + Send + Sync + 'static> DavInner<C> {
                 let mut multierror = MultiError::new(tx);
 
                 // see if we need to delete the destination first.
-                if overwrite && exists && (dest_is_file || (depth != Depth::Zero && !dest_is_file))
-                {
+                if overwrite && exists && (depth != Depth::Zero || dest_is_file) {
                     trace!("handle_copymove: deleting destination {dest}");
                     if self
                         .delete_items(&mut multierror, Depth::Infinity, dmeta.unwrap(), &dest)


### PR DESCRIPTION
WebDAV's MOVE semantics require that when _Overwrite: T_, the server removes the target resource (file or collection) before performing the rename. Currently the handler skips that removal when the destination is a non-collection, so the filesystem rename fails and the MOVE never happens. Litmus’ _move_coll_ (**copymove-10**) scenario exposes this: it MOVE's a collection onto an existing file and expects the destination to be replaced with the moved tree.

**Steps to reproduce**

1. Create a collection _/litmus/mvdest2/_ and put a child inside it.
2. Create a plain file /_litmus/mvnoncoll_.
3. Send MOVE /litmus/mvdest2/ with headers: "destination": "/litmus/mvnoncoll", "overwrite: T"

**Actual behavior**

The MOVE aborts because the file system rename sees an existing target and doesn’t overwrite it; the destination file remains untouched.

**Expected behavior**

Per RFC 4918, _Overwrite: T_ means the server must delete the destination resource first, regardless of whether it’s a file or collection, and then rename the source. After the MOVE:
  - _/litmus/mvnoncoll/_ should exist as the moved collection containing the former children of _/litmus/mvdest2/_.
  - _/litmus/mvdest2/_ should be gone (unless recreated later).
