### PR TITLE
Skip some tests if required features are disabled

### DIFF
--- a/src/voidfs.rs
+++ b/src/voidfs.rs
@@ -59,7 +59,7 @@ impl<C: Clone + Send + Sync + 'static> GuardedFileSystem<C> for VoidFs<C> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "memfs"))]
 mod tests {
     use super::*;
     use crate::memfs::MemFs;

--- a/tests/caldav_tests.rs
+++ b/tests/caldav_tests.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "caldav")]
+#[cfg(all(feature = "caldav", feature = "memfs"))]
 mod caldav_tests {
     use dav_server::{DavHandler, body::Body, caldav::*, fakels::FakeLs};
     use http::response::Response;
@@ -328,7 +328,7 @@ END:VCALENDAR"#;
     }
 }
 
-#[cfg(not(feature = "caldav"))]
+#[cfg(all(not(feature = "caldav"), feature = "memfs"))]
 mod caldav_disabled_tests {
     use dav_server::{DavHandler, body::Body, fakels::FakeLs, memfs::MemFs};
     use http::Request;

--- a/tests/carddav_tests.rs
+++ b/tests/carddav_tests.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "carddav")]
+#[cfg(all(feature = "carddav", feature = "memfs"))]
 mod carddav_tests {
     use dav_server::{DavHandler, body::Body, carddav::*, fakels::FakeLs, memfs::MemFs};
     use http::{Method, Request, StatusCode};
@@ -449,7 +449,7 @@ END:VCARD"#;
     }
 }
 
-#[cfg(not(feature = "carddav"))]
+#[cfg(all(not(feature = "carddav"), feature = "memfs"))]
 mod carddav_disabled_tests {
     use dav_server::{DavHandler, body::Body, fakels::FakeLs, memfs::MemFs};
     use http::Request;

--- a/tests/dav_tests.rs
+++ b/tests/dav_tests.rs
@@ -1,4 +1,4 @@
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", feature = "localfs"))]
 mod dav_tests {
     use dav_server::{DavHandler, DavOptionHide, body::Body, fakels::FakeLs, localfs::LocalFs};
     use http::{Request, StatusCode};


### PR DESCRIPTION
This fixes some compile errors that got flagged by tooling of the debian-rust team:

This should now work:
```
cargo check --tests --no-default-features

for f in actix-compat warp-compat caldav carddav all localfs memfs proppatch libc lru parking_lot hyper warp actix-web reflink-copy icalendar calcard; do
    cargo check --tests --no-default-features -F "$f"
done
```